### PR TITLE
build: support HONOR_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,14 @@ cmake_minimum_required(VERSION 3.10)
 
 project(kinova_mj_description VERSION 1.0.0)
 
-if(NOT TARGET mc_mujoco::mc_mujoco)
+option(HONOR_INSTALL_PREFIX "Whether to install in CMAKE_INSTALL_PREFIX (for nix)" OFF)
+option(SRC_MODE "Use files in the repository instead of installed files" OFF)
+
+if(HONOR_INSTALL_PREFIX)
+  set(MC_MUJOCO_SHARE_DESTINATION "${CMAKE_INSTALL_PREFIX}")
+else()
   find_package(mc_mujoco REQUIRED)
 endif()
-
-option(SRC_MODE "Use files in the repository instead of installed files" OFF)
 
 function(install_variant VARIANT)
   set(options)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 project(kinova_mj_description VERSION 1.0.0)
 
-if(NOT TARGET mc_mujoco)
+if(NOT TARGET mc_mujoco::mc_mujoco)
   find_package(mc_mujoco REQUIRED)
 endif()
 


### PR DESCRIPTION
Hi @mathieu-celerier ,

I got the error when trying to install this repo along with [ur5e_mj_description](https://github.com/isri-aist/ur5e_mj_description): add_library cannot create imported target "mc_mujoco::mc_mujoco" because another target with the same name already exists.

mc_mujoco package name is mc_mujoco::mc_mujoco. This change would fix that error.